### PR TITLE
fix signed overflow check

### DIFF
--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -968,7 +968,7 @@ lwip_recv_tcp(struct lwip_sock *sock, void *mem, size_t len, int flags)
     } else {
       copylen = (u16_t)recv_left;
     }
-    if (recvd + copylen < recvd) {
+    if (SSIZE_MAX - recvd < copylen) {
       /* overflow */
       copylen = (u16_t)(SSIZE_MAX - recvd);
     }


### PR DESCRIPTION
signed overflow check in the format of 'a + b < a' is an undefined behavior according to the C and C++ standards -> use a more appropriate one.